### PR TITLE
flatpickr-instance interfaces added

### DIFF
--- a/ng2-flatpickr.d.ts
+++ b/ng2-flatpickr.d.ts
@@ -2,3 +2,4 @@ export * from './src/ng2-flatpickr.component';
 export * from './src/ng2-flatpickr.directive';
 export * from './src/flatpickr-event.interface';
 export * from './src/flatpickr-options.interface';
+export * from './src/flatpickr-instance';


### PR DESCRIPTION
Added `flatpickr-instance` to typings file.

**Example:**
`import { FlatpickrInstance } from 'ng2-flatpickr/ng2-flatpickr';`