### PR TITLE
Fix for making ng2-flatpickr work with rxjs 6

### DIFF
--- a/src/ng2-flatpickr.directive.ts
+++ b/src/ng2-flatpickr.directive.ts
@@ -3,7 +3,7 @@ import {
 	OnDestroy, OnInit, Output, Renderer
 } from '@angular/core';
 import { ControlContainer, FormControl, NgControl } from '@angular/forms';
-import { Subscription } from 'rxjs/Subscription';
+import { Subscription } from 'rxjs';
 import { FlatpickrEvent } from './flatpickr-event.interface';
 import { FlatpickrInstance } from './flatpickr-instance';
 import { FlatpickrOptions } from './flatpickr-options.interface';


### PR DESCRIPTION
Yes, apparently you just need that.